### PR TITLE
登録画面のヘッダー修正

### DIFF
--- a/app/views/login/_header.html.haml
+++ b/app/views/login/_header.html.haml
@@ -1,4 +1,5 @@
-.account_header
-  .account_header_logo
-    = link_to "https://www.facebook.com/", class: "contents__btn" do
-      = image_tag "logo.svg", size: "185x49", alt: "logo"
+.account_body
+  .account_header
+    .account_header_logo
+      = link_to "https://www.facebook.com/", class: "contents__btn" do
+        = image_tag "logo.svg", size: "185x49", alt: "logo"


### PR DESCRIPTION
# WHY
新規登録画面のヘッダーをbodyが当たっておらず、崩れていたため修正。

# WHAT
ビューに統一性を持たせ、本番環境に反映させるため。