### PR TITLE
商品出品機能のエラー解消

### DIFF
--- a/app/views/shared/_product_new.html.haml
+++ b/app/views/shared/_product_new.html.haml
@@ -68,7 +68,7 @@
               .contents__detail__box__set__box__nini
                 任意
             .contents__detail__box__set__form
-              = f.collection_select :brand_id, @brand_array, {}, {class: 'contents__detail__box__set__form__detail__select'}
+              = f.select :brand_id, @brand_array, {}, {class: 'contents__detail__box__set__form'}
           .contents__detail__box__set
             .contents__detail__box__set__box
               .contents__detail__box__set__box__text


### PR DESCRIPTION
# what
商品出品機能のビューでエラーを修正した。
# why
商品のブランド選択のためのチェックボックスの記述が不適切なため。