### PR TITLE
fix_products/bu_select

### DIFF
--- a/app/views/shared/_product_new.html.haml
+++ b/app/views/shared/_product_new.html.haml
@@ -68,7 +68,7 @@
               .contents__detail__box__set__box__nini
                 任意
             .contents__detail__box__set__form
-              = f.collection_select :brand_id, @brand_array, {}, {class: 'contents__detail__box__set__form__detail__select'}
+              = f.select :brand_id, @brand_array, {}, {class: 'contents__detail__box__set__form__detail__select'}
           .contents__detail__box__set
             .contents__detail__box__set__box
               .contents__detail__box__set__box__text


### PR DESCRIPTION
# What
products_new のbrand_idの記述をcollection_sellectからselectへ修正

#Why
ページ遷移持のエラー回避のため
