### PR TITLE
product-index-update

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,8 +5,9 @@ class ProductsController < ApplicationController
 
 
   def index
-    @product = Product.includes(:images).order("created_at DESC").limit(3)
-    @brand = Product.where(brand_id: "2").last(3)
+    @purchase = Purchase.pluck('product_id')
+    @product = Product.includes(:images).where.not(id: @purchase).order("created_at DESC").limit(3)
+    @brand = Product.where(brand_id: "2").where.not(id: @purchase).last(3)
     @parents = Category.all.order("ancestry ASC").limit(13)
   end
 


### PR DESCRIPTION
# WHY
購入した商品が一覧に表示されないように変更。

# WHAT
既に売却された商品をユーザーに購入させないようにするため。